### PR TITLE
Animate the date scrubber and the section label when inactive

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.demoapp.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "9d95abde-8bcd-48eb-9a64-a5238aa9a179";
+				PROVISIONING_PROFILE = "5b41e501-5dc8-4084-ab2f-978bc7e82b9e";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -449,8 +449,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
@@ -458,7 +458,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.demoapp.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "9d95abde-8bcd-48eb-9a64-a5238aa9a179";
+				PROVISIONING_PROFILE = "5b41e501-5dc8-4084-ab2f-978bc7e82b9e";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -30,7 +30,7 @@ public class DateScrubber: UIViewController {
 
     private let dragGestureRecognizer = UIPanGestureRecognizer()
 
-    private var viewIsBeingDragged = false
+    private var timer : NSTimer?
 
     public var sectionLabelImage: UIImage? {
         didSet {
@@ -65,6 +65,17 @@ public class DateScrubber: UIViewController {
         didSet {
             if let textColor = self.textColor {
                 sectionLabel.setTextColor(textColor)
+            }
+        }
+    }
+
+    private var viewIsBeingDragged = false {
+        didSet{
+            if self.viewIsBeingDragged {
+              self.setSectionLabelActive()
+            } else {
+
+                self.setSectionLabelInactive()
             }
         }
     }
@@ -110,7 +121,9 @@ public class DateScrubber: UIViewController {
 
     func handleDrag(gestureRecognizer : UIPanGestureRecognizer) {
 
-        self.viewIsBeingDragged = gestureRecognizer.state != .Ended
+        if self.viewIsBeingDragged != (gestureRecognizer.state != .Ended) {
+            self.viewIsBeingDragged = gestureRecognizer.state != .Ended
+        }
 
         if gestureRecognizer.state == .Began || gestureRecognizer.state == .Changed {
 
@@ -141,6 +154,14 @@ public class DateScrubber: UIViewController {
 
     private func setSectionlabelFrame(){
         self.sectionLabel.frame = CGRectMake(self.view.frame.width - SectionLabel.RightOffsetForSectionLabel - self.sectionLabel.sectionlabelWidth, 0, self.sectionLabel.sectionlabelWidth, viewHeight)
+    }
 
+    private func setSectionLabelActive(){
+        timer = nil
+        self.sectionLabel.show()
+    }
+
+    private func setSectionLabelInactive(){
+       timer = NSTimer.scheduledTimerWithTimeInterval(2, target: self.sectionLabel, selector: #selector(SectionLabel.hide), userInfo: nil, repeats: false)
     }
 }

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -182,34 +182,39 @@ public class DateScrubber: UIViewController {
         if self.sectionLabelActive {
             return
         }
-
         self.sectionLabelActive = true
 
-        timer = nil
-        NSObject.cancelPreviousPerformRequestsWithTarget(self.sectionLabel, selector: #selector(SectionLabel.hide), object: nil)
-
-        print("resetting the timer")
-
         self.animateFrameToActiveState(true)
-
         self.sectionLabel.show()
     }
 
     private func setSectionLabelInactive() {
 
-        self.animateFrameToActiveState(false)
-        print("setting the timer")
-        NSObject.cancelPreviousPerformRequestsWithTarget(self.sectionLabel, selector: #selector(SectionLabel.hide), object: nil)
-        timer = NSTimer.scheduledTimerWithTimeInterval(2, target: self.sectionLabel, selector: #selector(SectionLabel.hide), userInfo: nil, repeats: false)
+        if !self.sectionLabelActive {
+            return
+        }
         self.sectionLabelActive = false
+
+        self.animateFrameToActiveState(false)
+
+        NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(hideSectionLabel), object: nil)
+        self.performSelector(#selector(hideSectionLabel), withObject: nil, afterDelay: 3)
+
     }
 
-    private func animateFrameToActiveState(active : Bool){
+    func hideSectionLabel(){
+        if self.sectionLabelActive {
+            return
+        }
+        self.sectionLabel.hide()
+    }
+
+    private func animateFrameToActiveState(active: Bool) {
         var newSectionLabelFrame = self.sectionLabel.frame
-        newSectionLabelFrame.origin.x = active ? newSectionLabelFrame.origin.x  - 20 : newSectionLabelFrame.origin.x  + 20
+        newSectionLabelFrame.origin.x = active ? newSectionLabelFrame.origin.x - 20 : newSectionLabelFrame.origin.x + 20
 
         UIView.animateWithDuration(0.2, animations: {
-        self.sectionLabel.frame = newSectionLabelFrame
+            self.sectionLabel.frame = newSectionLabelFrame
         })
     }
 }

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -29,6 +29,7 @@ public class DateScrubber: UIViewController {
     private let sectionLabel = SectionLabel()
 
     private let dragGestureRecognizer = UIPanGestureRecognizer()
+    private let longPressGestureRecognizer = UILongPressGestureRecognizer()
 
     private var timer : NSTimer?
 
@@ -87,8 +88,15 @@ public class DateScrubber: UIViewController {
         self.view.addSubview(self.sectionLabel)
 
         self.dragGestureRecognizer.addTarget(self, action: #selector(handleDrag))
+        self.dragGestureRecognizer
         self.scrubberImageView.userInteractionEnabled  = true
         self.scrubberImageView.addGestureRecognizer(self.dragGestureRecognizer)
+
+        self.longPressGestureRecognizer.addTarget(self, action: #selector(handleLongPress))
+        self.longPressGestureRecognizer.minimumPressDuration = 0.2
+        self.longPressGestureRecognizer.cancelsTouchesInView = false
+        self.longPressGestureRecognizer.delegate = self
+        self.scrubberImageView.addGestureRecognizer(self.longPressGestureRecognizer)
     }
 
     public func updateFrame(scrollView scrollView: UIScrollView) {
@@ -117,6 +125,17 @@ public class DateScrubber: UIViewController {
 
         let percentageInView = (yPosInView - containingViewFrame.minY) / containingViewFrame.height
         return (containingViewContentSize.height * percentageInView) - containingViewFrame.minY
+    }
+
+    func handleLongPress(gestureRecognizer: UITapGestureRecognizer) {
+
+        if gestureRecognizer.state == .Began {
+            self.setSectionLabelActive()
+        }
+
+        if gestureRecognizer.state == .Ended && !self.viewIsBeingDragged {
+            self.setSectionLabelInactive()
+        }
     }
 
     func handleDrag(gestureRecognizer : UIPanGestureRecognizer) {
@@ -163,5 +182,11 @@ public class DateScrubber: UIViewController {
 
     private func setSectionLabelInactive(){
        timer = NSTimer.scheduledTimerWithTimeInterval(2, target: self.sectionLabel, selector: #selector(SectionLabel.hide), userInfo: nil, repeats: false)
+    }
+}
+
+extension DateScrubber : UIGestureRecognizerDelegate {
+     public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -103,7 +103,6 @@ public class DateScrubber: UIViewController {
         self.view.addSubview(self.sectionLabel)
 
         self.dragGestureRecognizer.addTarget(self, action: #selector(handleDrag))
-        self.dragGestureRecognizer
         self.scrubberImageView.userInteractionEnabled  = true
         self.scrubberImageView.addGestureRecognizer(self.dragGestureRecognizer)
 
@@ -206,8 +205,12 @@ public class DateScrubber: UIViewController {
     }
 
     private func setScrubberFrame(){
-        let xPos = self.scrubberState == .Visible ? self.containingViewFrame.width -  self.scrubberWidth - DateScrubber.RightEdgeInset : self.containingViewFrame.width
-        scrubberImageView.frame = CGRectMake(xPos, 0, self.scrubberWidth, self.viewHeight)
+        switch self.scrubberState {
+            case .Visible:
+                scrubberImageView.frame = CGRectMake(self.containingViewFrame.width - self.scrubberWidth - DateScrubber.RightEdgeInset, 0, self.scrubberWidth, self.viewHeight)
+            case .Hidden:
+                scrubberImageView.frame = CGRectMake(self.containingViewFrame.width, 0, self.scrubberWidth, self.viewHeight)
+        }
     }
 
     private func setSectionLabelActive(){
@@ -221,16 +224,16 @@ public class DateScrubber: UIViewController {
 
     private func updateSectionLabelFrame() {
 
-        UIView.animateWithDuration(0.2, animations: {
+        UIView.animateWithDuration(0.2) {
             self.setSectionlabelFrame()
-        })
+        }
     }
 
     private func updateDateScrubberFrame() {
 
-        UIView.animateWithDuration(0.2, animations: {
+        UIView.animateWithDuration(0.2){
             self.setScrubberFrame()
-        })
+        }
     }
 
     func hideScrubber(){

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -81,17 +81,6 @@ public class DateScrubber: UIViewController {
         }
     }
 
-//    private var viewIsBeingDragged = false {
-//        didSet{
-//            if self.viewIsBeingDragged {
-//              self.setSectionLabelActive()
-//            } else {
-//
-//                self.setSectionLabelInactive()
-//            }
-//        }
-//    }
-
     private var sectionLabelState = State.Inactive {
         didSet {
 
@@ -227,7 +216,6 @@ public class DateScrubber: UIViewController {
     }
 
     private func setSectionLabelInactive() {
-        print("\(NSDate()) setting timer to hide section label")
         self.performSelector(#selector(hideSectionLabel), withObject: nil, afterDelay: 3)
     }
 
@@ -250,7 +238,6 @@ public class DateScrubber: UIViewController {
     }
 
     func hideSectionLabel(){
-        print("\(NSDate()) actually hiding it")
         self.sectionLabel.hide()
     }
 }

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -15,9 +15,9 @@ public extension DateScrubberDelegate where Self: UICollectionViewController {
 
 public class DateScrubber: UIViewController {
 
-    enum State {
-        case Inactive
-        case Active
+    enum VisibilityState {
+        case Hidden
+        case Visible
     }
 
     static let RightEdgeInset: CGFloat = 5.0
@@ -81,16 +81,16 @@ public class DateScrubber: UIViewController {
         }
     }
 
-    private var sectionLabelState = State.Inactive {
+    private var sectionLabelState = VisibilityState.Hidden {
         didSet {
 
-            if self.sectionLabelState == .Active {self.setSectionLabelActive()}
-            if self.sectionLabelState == .Inactive {self.setSectionLabelInactive()}
+            if self.sectionLabelState == .Visible {self.setSectionLabelActive()}
+            if self.sectionLabelState == .Hidden {self.setSectionLabelInactive()}
             self.updateSectionLabelFrame()
         }
     }
 
-    private var scrubberState = State.Inactive {
+    private var scrubberState = VisibilityState.Hidden {
         didSet {
             self.updateDateScrubberFrame()
         }
@@ -122,7 +122,7 @@ public class DateScrubber: UIViewController {
 
         self.userInteractionOnScrollViewDetected()
 
-        if self.sectionLabelState == .Active {
+        if self.sectionLabelState == .Visible {
             return
         }
 
@@ -146,8 +146,8 @@ public class DateScrubber: UIViewController {
         NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(hideScrubber), object: nil)
         self.performSelector(#selector(hideScrubber), withObject: nil, afterDelay: 3)
 
-        if self.scrubberState == .Inactive {
-            self.scrubberState = .Active
+        if self.scrubberState == .Hidden {
+            self.scrubberState = .Visible
         }
     }
 
@@ -165,12 +165,12 @@ public class DateScrubber: UIViewController {
 
     func handleLongPress(gestureRecognizer: UITapGestureRecognizer) {
 
-        self.sectionLabelState = gestureRecognizer.state == .Ended ? .Inactive : .Active
+        self.sectionLabelState = gestureRecognizer.state == .Ended ? .Hidden : .Visible
     }
 
     func handleDrag(gestureRecognizer : UIPanGestureRecognizer) {
 
-        self.sectionLabelState = gestureRecognizer.state == .Ended ? .Inactive : .Active
+        self.sectionLabelState = gestureRecognizer.state == .Ended ? .Hidden : .Visible
 
         if gestureRecognizer.state == .Began || gestureRecognizer.state == .Changed {
 
@@ -201,12 +201,12 @@ public class DateScrubber: UIViewController {
 
     private func setSectionlabelFrame(){
 
-        let rightOffset = self.sectionLabelState == .Active ? SectionLabel.RightOffsetForActiveSectionLabel : SectionLabel.RightOffsetForInactiveSectionLabel
+        let rightOffset = self.sectionLabelState == .Visible ? SectionLabel.RightOffsetForActiveSectionLabel : SectionLabel.RightOffsetForInactiveSectionLabel
         self.sectionLabel.frame = CGRectMake(self.view.frame.width - rightOffset - self.sectionLabel.sectionlabelWidth, 0, self.sectionLabel.sectionlabelWidth, viewHeight)
     }
 
     private func setScrubberFrame(){
-        let xPos = self.scrubberState == .Active ? self.containingViewFrame.width -  self.scrubberWidth - DateScrubber.RightEdgeInset : self.containingViewFrame.width
+        let xPos = self.scrubberState == .Visible ? self.containingViewFrame.width -  self.scrubberWidth - DateScrubber.RightEdgeInset : self.containingViewFrame.width
         scrubberImageView.frame = CGRectMake(xPos, 0, self.scrubberWidth, self.viewHeight)
     }
 
@@ -234,7 +234,7 @@ public class DateScrubber: UIViewController {
     }
 
     func hideScrubber(){
-        self.scrubberState = .Inactive
+        self.scrubberState = .Hidden
     }
 
     func hideSectionLabel(){

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -33,6 +33,8 @@ public class DateScrubber: UIViewController {
 
     private var timer : NSTimer?
 
+    private var sectionLabelActive = false
+
     public var sectionLabelImage: UIImage? {
         didSet {
             if let sectionLabelImage = self.sectionLabelImage {
@@ -176,12 +178,39 @@ public class DateScrubber: UIViewController {
     }
 
     private func setSectionLabelActive(){
+
+        if self.sectionLabelActive {
+            return
+        }
+
+        self.sectionLabelActive = true
+
         timer = nil
+        NSObject.cancelPreviousPerformRequestsWithTarget(self.sectionLabel, selector: #selector(SectionLabel.hide), object: nil)
+
+        print("resetting the timer")
+
+        self.animateFrameToActiveState(true)
+
         self.sectionLabel.show()
     }
 
-    private func setSectionLabelInactive(){
-       timer = NSTimer.scheduledTimerWithTimeInterval(2, target: self.sectionLabel, selector: #selector(SectionLabel.hide), userInfo: nil, repeats: false)
+    private func setSectionLabelInactive() {
+
+        self.animateFrameToActiveState(false)
+        print("setting the timer")
+        NSObject.cancelPreviousPerformRequestsWithTarget(self.sectionLabel, selector: #selector(SectionLabel.hide), object: nil)
+        timer = NSTimer.scheduledTimerWithTimeInterval(2, target: self.sectionLabel, selector: #selector(SectionLabel.hide), userInfo: nil, repeats: false)
+        self.sectionLabelActive = false
+    }
+
+    private func animateFrameToActiveState(active : Bool){
+        var newSectionLabelFrame = self.sectionLabel.frame
+        newSectionLabelFrame.origin.x = active ? newSectionLabelFrame.origin.x  - 20 : newSectionLabelFrame.origin.x  + 20
+
+        UIView.animateWithDuration(0.2, animations: {
+        self.sectionLabel.frame = newSectionLabelFrame
+        })
     }
 }
 

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -41,8 +41,6 @@ public class DateScrubber: UIViewController {
     private let dragGestureRecognizer = UIPanGestureRecognizer()
     private let longPressGestureRecognizer = UILongPressGestureRecognizer()
 
-    private var timer : NSTimer?
-
     public var sectionLabelImage: UIImage? {
         didSet {
             if let sectionLabelImage = self.sectionLabelImage {

--- a/Sources/DateScrubber.swift
+++ b/Sources/DateScrubber.swift
@@ -41,6 +41,8 @@ public class DateScrubber: UIViewController {
 
     public var containingViewContentSize = UIScreen.mainScreen().bounds.size
 
+    private var currentSectionTitle = ""
+
     private let scrubberImageView = UIImageView()
 
     private let sectionLabel = SectionLabel()
@@ -135,8 +137,13 @@ public class DateScrubber: UIViewController {
     }
 
     public func updateSectionTitle(title : String){
+
+        if self.currentSectionTitle != title {
+            self.currentSectionTitle = title
+
         self.sectionLabel.setText(title)
         self.setSectionlabelFrame()
+        }
     }
 
     private func calculateYPosInView(forYPosInContentView yPosInContentView: CGFloat) -> CGFloat{

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -59,15 +59,15 @@ class SectionLabel: UIView {
 
     func hide() {
 
-        UIView.animateWithDuration(0.2, animations: {
+        UIView.animateWithDuration(0.2){
             self.alpha = 0
-        })
+        }
     }
 
     func show(){
 
-        UIView.animateWithDuration(0.2, animations: {
+        UIView.animateWithDuration(0.2) {
             self.alpha = 1
-        })
+        }
     }
 }

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -1,11 +1,3 @@
-//
-//  SectionLabel.swift
-//  Demo
-//
-//  Created by Marijn Schilling on 06/06/16.
-//
-//
-
 import UIKit
 
 class SectionLabel: UIView {
@@ -61,7 +53,17 @@ class SectionLabel: UIView {
         self.setNeedsLayout()
     }
 
-    func hide(){}
+    func hide(){
 
-    func show(){}
+        UIView.animateWithDuration(0.2, animations: {
+            self.alpha = 0
+        })
+    }
+
+    func show(){
+
+        UIView.animateWithDuration(0.2, animations: {
+            self.alpha = 1
+        })
+    }
 }

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -2,7 +2,9 @@ import UIKit
 
 class SectionLabel: UIView {
 
-    static let RightOffsetForSectionLabel : CGFloat = 80.0
+    static let RightOffsetForActiveSectionLabel: CGFloat = 80.0
+    static let RightOffsetForInactiveSectionLabel: CGFloat = 60.0
+
     private static let Margin : CGFloat = 19.0
 
     var sectionlabelWidth : CGFloat {

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -59,10 +59,7 @@ class SectionLabel: UIView {
 
         UIView.animateWithDuration(0.2, animations: {
             self.alpha = 0
-        }) {
-            (bool) in
-            print("done with hiding")
-        }
+        })
     }
 
     func show(){

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class SectionLabel: UIView {
 
-    static let RightOffsetForSectionLabel : CGFloat = 90.0
+    static let RightOffsetForSectionLabel : CGFloat = 80.0
     private static let Margin : CGFloat = 19.0
 
     var sectionlabelWidth : CGFloat {
@@ -55,11 +55,14 @@ class SectionLabel: UIView {
         self.setNeedsLayout()
     }
 
-    func hide(){
+    func hide() {
 
         UIView.animateWithDuration(0.2, animations: {
             self.alpha = 0
-        })
+        }) {
+            (bool) in
+            print("done with hiding")
+        }
     }
 
     func show(){

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -28,6 +28,8 @@ class SectionLabel: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        self.hide()
+
         self.addSubview(self.textLabel)
     }
 

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -8,12 +8,6 @@ class RemoteCollectionController: UICollectionViewController, DateScrubberDelega
 
     let testView = UIView()
 
-    var titleForVisibleSection = "" {
-        didSet{
-            self.dateScrubber.updateSectionTitle(self.titleForVisibleSection)
-        }
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -103,9 +97,7 @@ extension RemoteCollectionController{
         let centerPoint = CGPoint(x: dateScrubber.view.center.x + scrollView.contentOffset.x, y: dateScrubber.view.center.y + scrollView.contentOffset.y);
 
         if let indexPath = self.collectionView?.indexPathForItemAtPoint(centerPoint) {
-            if titleForVisibleSection != sectionTitleFor(indexPath.section){
-                titleForVisibleSection = sectionTitleFor(indexPath.section)
-            }
+            self.dateScrubber.updateSectionTitle(sectionTitleFor(indexPath.section))
         }
     }
 }


### PR DESCRIPTION
The scrubber appears and moves along when scrolling through the collection view, and disappears when there's no interaction for 3 seconds.

The sectionLabel fades in and moves a bit to the left when the scrubber is pressed to "scrub" through the collection view. When the scrubber is released the label moves back to the right. And fades out after 3 seconds.

![alt tag](https://media.giphy.com/media/xT8qBsHiBYhAp0EomI/giphy.gif)
- There is one bug where I hide the sectionlabel after a 3 second delay (with `performSelector: withObject: afterDelay:`) But when I scroll the collectionView during that time, it only hides it after I stop that 🤔
- So scrolling the collectionview activates the scrubber and using a gesture on the scrubber activates the section label. I implemented some logic to keep track of when to hide and show them, but I'm wondering if I could be more clear. It can be a bit confusing now. Any tips are welcome!
