### PR TITLE
Remove self when it's not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ From your UICollectionViewController:
 
 ```swift
 lazy var sectionScrubber: SectionScrubber = {
-    let scrubber = SectionScrubber(collectionView: self.collectionView!)
+    let scrubber = SectionScrubber(collectionView: collectionView!)
     scrubber.scrubberImage = UIImage(named: "date-scrubber")
     scrubber.sectionLabelImage = UIImage(named: "section-label")
     scrubber.sectionLabelFont = UIFont(name: "DINNextLTPro-Light", size: 18)
@@ -28,23 +28,23 @@ lazy var sectionScrubber: SectionScrubber = {
 
 override func viewDidLoad() {
     super.viewDidLoad()
-    self.view.addSubview(sectionScrubber.view)
+    view.addSubview(sectionScrubber.view)
 }
 
 override func scrollViewDidScroll(scrollView: UIScrollView) {
-    self.sectionScrubber.updateFrame { indexPath in
+    sectionScrubber.updateFrame { indexPath in
         if let indexPath = indexPath {
             let title = titleForIndexPath(indexPath)
-            self.sectionScrubber.updateSectionTitle(title)
+            sectionScrubber.updateSectionTitle(title)
         }
     }
 }
 
 override func scrollViewDidEndDragging(scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    self.sectionScrubber.updateFrame { indexPath in
+    sectionScrubber.updateFrame { indexPath in
         if let indexPath = indexPath {
             let title = titleForIndexPath(indexPath)
-            self.sectionScrubber.updateSectionTitle(title)
+            sectionScrubber.updateSectionTitle(title)
         }
     }
 }

--- a/Sources/SectionLabel.swift
+++ b/Sources/SectionLabel.swift
@@ -7,7 +7,7 @@ class SectionLabel: UIView {
     private static let Margin : CGFloat = 19.0
 
     var sectionlabelWidth : CGFloat {
-        return self.textLabel.width() + (2 * SectionLabel.Margin) + 4
+        return textLabel.width() + (2 * SectionLabel.Margin) + 4
     }
 
     private let sectionLabelImageView = UIImageView()
@@ -16,10 +16,10 @@ class SectionLabel: UIView {
 
     var labelImage: UIImage? {
         didSet {
-            if let labelImage = self.labelImage {
-                self.sectionLabelImageView.image = labelImage
-                self.addSubview(sectionLabelImageView)
-                self.bringSubviewToFront(self.textLabel)
+            if let labelImage = labelImage {
+                sectionLabelImageView.image = labelImage
+                addSubview(sectionLabelImageView)
+                bringSubviewToFront(textLabel)
             }
         }
     }
@@ -27,9 +27,9 @@ class SectionLabel: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.hide()
+        hide()
 
-        self.addSubview(self.textLabel)
+        addSubview(textLabel)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -37,21 +37,21 @@ class SectionLabel: UIView {
     }
 
     override func layoutSubviews() {
-        self.sectionLabelImageView.frame = self.bounds
-        self.textLabel.frame = CGRectMake(SectionLabel.Margin, SectionLabel.Margin, self.textLabel.width(), 22)
+        sectionLabelImageView.frame = bounds
+        textLabel.frame = CGRectMake(SectionLabel.Margin, SectionLabel.Margin, textLabel.width(), 22)
     }
 
     func setFont(font : UIFont){
-         self.textLabel.font = font
+         textLabel.font = font
     }
 
     func setTextColor(color : UIColor){
-         self.textLabel.textColor = color
+         textLabel.textColor = color
     }
 
     func setText(text: String){
-        self.textLabel.text = text
-        self.setNeedsLayout()
+        textLabel.text = text
+        setNeedsLayout()
     }
 
     func hide() {

--- a/Sources/SectionScrubber.swift
+++ b/Sources/SectionScrubber.swift
@@ -40,9 +40,9 @@ public class SectionScrubber: UIView {
 
     public var sectionLabelImage: UIImage? {
         didSet {
-            if let sectionLabelImage = self.sectionLabelImage {
-                self.sectionLabel.labelImage = sectionLabelImage
-                self.viewHeight = sectionLabelImage.size.height
+            if let sectionLabelImage = sectionLabelImage {
+                sectionLabel.labelImage = sectionLabelImage
+                viewHeight = sectionLabelImage.size.height
             }
         }
     }
@@ -55,16 +55,16 @@ public class SectionScrubber: UIView {
 
     public var scrubberImage: UIImage? {
         didSet {
-            if let scrubberImage = self.scrubberImage {
-                self.scrubberWidth = scrubberImage.size.width
-                self.scrubberImageView.image = scrubberImage
+            if let scrubberImage = scrubberImage {
+                scrubberWidth = scrubberImage.size.width
+                scrubberImageView.image = scrubberImage
             }
         }
     }
 
     public var sectionLabelFont: UIFont? {
         didSet {
-            if let sectionLabelFont = self.sectionLabelFont {
+            if let sectionLabelFont = sectionLabelFont {
                 sectionLabel.setFont(sectionLabelFont)
             }
         }
@@ -72,7 +72,7 @@ public class SectionScrubber: UIView {
 
     public var sectionlabelTextColor: UIColor? {
         didSet {
-            if let sectionlabelTextColor = self.sectionlabelTextColor {
+            if let sectionlabelTextColor = sectionlabelTextColor {
                 sectionLabel.setTextColor(sectionlabelTextColor)
             }
         }
@@ -80,18 +80,18 @@ public class SectionScrubber: UIView {
 
     private var sectionLabelState = VisibilityState.Hidden {
         didSet {
-            if self.sectionLabelState != oldValue {
-                if self.sectionLabelState == .Visible { self.setSectionLabelActive() }
-                if self.sectionLabelState == .Hidden { self.setSectionLabelInactive() }
-                self.updateSectionLabelFrame()
+            if sectionLabelState != oldValue {
+                if sectionLabelState == .Visible { setSectionLabelActive() }
+                if sectionLabelState == .Hidden { setSectionLabelInactive() }
+                updateSectionLabelFrame()
             }
         }
     }
 
     private var scrubberState = VisibilityState.Hidden {
         didSet {
-            if self.scrubberState != oldValue {
-                self.updateSectionScrubberFrame()
+            if scrubberState != oldValue {
+                updateSectionScrubberFrame()
             }
         }
     }
@@ -101,24 +101,24 @@ public class SectionScrubber: UIView {
 
         super.init(frame: CGRectZero)
 
-        self.setScrubberFrame()
-        self.addSubview(self.scrubberImageView)
+        setScrubberFrame()
+        addSubview(scrubberImageView)
 
-        self.setSectionlabelFrame()
-        self.addSubview(self.sectionLabel)
+        setSectionlabelFrame()
+        addSubview(sectionLabel)
 
-        self.dragGestureRecognizer.addTarget(self, action: #selector(self.handleScrub))
-        self.dragGestureRecognizer.delegate = self
+        dragGestureRecognizer.addTarget(self, action: #selector(handleScrub))
+        dragGestureRecognizer.delegate = self
 
-        self.longPressGestureRecognizer.addTarget(self, action: #selector(self.handleScrub))
-        self.longPressGestureRecognizer.minimumPressDuration = 0.2
-        self.longPressGestureRecognizer.cancelsTouchesInView = false
-        self.longPressGestureRecognizer.delegate = self
+        longPressGestureRecognizer.addTarget(self, action: #selector(handleScrub))
+        longPressGestureRecognizer.minimumPressDuration = 0.2
+        longPressGestureRecognizer.cancelsTouchesInView = false
+        longPressGestureRecognizer.delegate = self
 
-        let scrubberGestureView = UIView(frame: CGRectMake(self.containingViewFrame.width - self.scrubberGestureWidth, 0, self.scrubberGestureWidth, self.viewHeight))
-        scrubberGestureView.addGestureRecognizer(self.longPressGestureRecognizer)
-        scrubberGestureView.addGestureRecognizer(self.dragGestureRecognizer)
-        self.addSubview(scrubberGestureView)
+        let scrubberGestureView = UIView(frame: CGRectMake(containingViewFrame.width - scrubberGestureWidth, 0, scrubberGestureWidth, viewHeight))
+        scrubberGestureView.addGestureRecognizer(longPressGestureRecognizer)
+        scrubberGestureView.addGestureRecognizer(dragGestureRecognizer)
+        addSubview(scrubberGestureView)
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -126,39 +126,39 @@ public class SectionScrubber: UIView {
     }
 
     public func updateFrame(completion: ((indexPath: NSIndexPath?) -> Void)) {
-        self.userInteractionOnScrollViewDetected()
+        userInteractionOnScrollViewDetected()
 
-        let yPos = self.calculateYPosInView(forYPosInContentView: self.collectionView.contentOffset.y + self.containingViewFrame.minY)
+        let yPos = calculateYPosInView(forYPosInContentView: collectionView.contentOffset.y + containingViewFrame.minY)
         if yPos > 0 {
-            self.setFrame(atYpos: yPos)
+            setFrame(atYpos: yPos)
         }
 
-        let centerPoint = CGPoint(x: self.center.x + self.collectionView.contentOffset.x, y: self.center.y + self.collectionView.contentOffset.y);
-        let indexPath = self.collectionView.indexPathForItemAtPoint(centerPoint)
+        let centerPoint = CGPoint(x: center.x + collectionView.contentOffset.x, y: center.y + collectionView.contentOffset.y);
+        let indexPath = collectionView.indexPathForItemAtPoint(centerPoint)
         completion(indexPath: indexPath)
     }
 
     public func updateSectionTitle(title: String) {
-        if self.currentSectionTitle != title {
-            self.currentSectionTitle = title
+        if currentSectionTitle != title {
+            currentSectionTitle = title
 
-            self.sectionLabel.setText(title)
-            self.setSectionlabelFrame()
+            sectionLabel.setText(title)
+            setSectionlabelFrame()
         }
     }
 
     private func userInteractionOnScrollViewDetected() {
-        NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(self.hideScrubber), object: nil)
-        self.performSelector(#selector(self.hideScrubber), withObject: nil, afterDelay: 2)
+        NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(hideScrubber), object: nil)
+        performSelector(#selector(hideScrubber), withObject: nil, afterDelay: 2)
 
-        if self.scrubberState == .Hidden {
-            self.scrubberState = .Visible
+        if scrubberState == .Hidden {
+            scrubberState = .Visible
         }
     }
 
     func calculateYPosInView(forYPosInContentView yPosInContentView: CGFloat) -> CGFloat {
-        let percentageInContentView = yPosInContentView / self.containingViewContentSize.height
-        let y =  (self.containingViewFrame.height * percentageInContentView) + self.containingViewFrame.minY
+        let percentageInContentView = yPosInContentView / containingViewContentSize.height
+        let y =  (containingViewFrame.height * percentageInContentView) + containingViewFrame.minY
 
         return y
     }
@@ -169,59 +169,59 @@ public class SectionScrubber: UIView {
     }
 
     func handleScrub(gestureRecognizer: UIGestureRecognizer) {
-        self.sectionLabelState = gestureRecognizer.state == .Ended ? .Hidden : .Visible
-        self.userInteractionOnScrollViewDetected()
+        sectionLabelState = gestureRecognizer.state == .Ended ? .Hidden : .Visible
+        userInteractionOnScrollViewDetected()
 
         if let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer where panGestureRecognizer.state == .Began || panGestureRecognizer.state == .Changed {
 
             let translation = panGestureRecognizer.translationInView(self)
-            var newYPosForSectionScrubber = self.frame.origin.y + translation.y
+            var newYPosForSectionScrubber = frame.origin.y + translation.y
 
             if newYPosForSectionScrubber < containingViewFrame.minY {
                 newYPosForSectionScrubber = containingViewFrame.minY
             }
 
-            if newYPosForSectionScrubber > self.containingViewFrame.size.height + self.containingViewFrame.minY - bottomBorderOffset {
-                newYPosForSectionScrubber = self.containingViewFrame.size.height + self.containingViewFrame.minY - bottomBorderOffset
+            if newYPosForSectionScrubber > containingViewFrame.size.height + containingViewFrame.minY - bottomBorderOffset {
+                newYPosForSectionScrubber = containingViewFrame.size.height + containingViewFrame.minY - bottomBorderOffset
             }
 
-            self.setFrame(atYpos: newYPosForSectionScrubber)
+            setFrame(atYpos: newYPosForSectionScrubber)
 
             let yPosInContentInContentView = calculateYPosInContentView(forYPosInView: newYPosForSectionScrubber)
 
-            self.collectionView.setContentOffset(CGPoint(x: 0, y: yPosInContentInContentView), animated: false)
+            collectionView.setContentOffset(CGPoint(x: 0, y: yPosInContentInContentView), animated: false)
 
             panGestureRecognizer.setTranslation(CGPoint(x: translation.x, y: 0), inView: self)
         }
     }
 
     private func setFrame(atYpos yPos: CGFloat) {
-        self.frame = CGRect(x: 0, y: yPos, width: UIScreen.mainScreen().bounds.width, height: self.viewHeight)
+        frame = CGRect(x: 0, y: yPos, width: UIScreen.mainScreen().bounds.width, height: viewHeight)
     }
 
     private func setSectionlabelFrame() {
-        let rightOffset = self.sectionLabelState == .Visible ? SectionLabel.RightOffsetForActiveSectionLabel : SectionLabel.RightOffsetForInactiveSectionLabel
-        self.sectionLabel.frame = CGRectMake(self.frame.width - rightOffset - self.sectionLabel.sectionlabelWidth, 0, self.sectionLabel.sectionlabelWidth, viewHeight)
+        let rightOffset = sectionLabelState == .Visible ? SectionLabel.RightOffsetForActiveSectionLabel : SectionLabel.RightOffsetForInactiveSectionLabel
+        sectionLabel.frame = CGRectMake(frame.width - rightOffset - sectionLabel.sectionlabelWidth, 0, sectionLabel.sectionlabelWidth, viewHeight)
     }
 
     private func setScrubberFrame() {
-        switch self.scrubberState {
+        switch scrubberState {
         case .Visible:
-            scrubberImageView.frame = CGRectMake(self.containingViewFrame.width - self.scrubberWidth - SectionScrubber.RightEdgeInset, 0, self.scrubberWidth, self.viewHeight)
+            scrubberImageView.frame = CGRectMake(containingViewFrame.width - scrubberWidth - SectionScrubber.RightEdgeInset, 0, scrubberWidth, viewHeight)
         case .Hidden:
-            scrubberImageView.frame = CGRectMake(self.containingViewFrame.width, 0, self.scrubberWidth, self.viewHeight)
+            scrubberImageView.frame = CGRectMake(containingViewFrame.width, 0, scrubberWidth, viewHeight)
         }
     }
 
     private func setSectionLabelActive() {
-        self.delegate?.sectionScrubberDidStartScrubbing(self)
-        self.sectionLabel.show()
+        delegate?.sectionScrubberDidStartScrubbing(self)
+        sectionLabel.show()
     }
 
     private func setSectionLabelInactive() {
-        self.delegate?.sectionScrubberDidStopScrubbing(self)
+        delegate?.sectionScrubberDidStopScrubbing(self)
         NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(hideSectionLabel), object: nil)
-        self.performSelector(#selector(hideSectionLabel), withObject: nil, afterDelay: 2)
+        performSelector(#selector(hideSectionLabel), withObject: nil, afterDelay: 2)
     }
 
     private func updateSectionLabelFrame() {
@@ -237,26 +237,26 @@ public class SectionScrubber: UIView {
     }
 
     func hideScrubber() {
-        self.scrubberState = .Hidden
+        scrubberState = .Hidden
     }
 
     func hideSectionLabel() {
-        guard self.sectionLabelState != .Visible else {
+        guard sectionLabelState != .Visible else {
             return
         }
-        self.sectionLabel.hide()
+        sectionLabel.hide()
     }
 
     var originalOriginY: CGFloat?
     override public func layoutSubviews() {
-        if self.originalOriginY == nil {
-            self.originalOriginY = -self.collectionView.bounds.origin.y
+        if originalOriginY == nil {
+            originalOriginY = -collectionView.bounds.origin.y
         }
 
-        if let originalOriginY = self.originalOriginY {
-            self.containingViewFrame = CGRectMake(0, originalOriginY, self.collectionView.bounds.width, self.collectionView.bounds.height - originalOriginY - self.viewHeight)
-            self.containingViewContentSize = self.collectionView.contentSize
-            self.updateFrame() { _ in }
+        if let originalOriginY = originalOriginY {
+            containingViewFrame = CGRectMake(0, originalOriginY, collectionView.bounds.width, collectionView.bounds.height - originalOriginY - viewHeight)
+            containingViewContentSize = collectionView.contentSize
+            updateFrame() { _ in }
         }
     }
 }

--- a/Sources/UILabel+Sweetness.swift
+++ b/Sources/UILabel+Sweetness.swift
@@ -2,8 +2,8 @@ import UIKit
 
 extension UILabel {
 func width() -> CGFloat {
-        let attributes = [NSFontAttributeName : self.font]
-        let rect = (self.text ?? "" as NSString).boundingRectWithSize(CGSize(width: CGFloat.max, height: CGFloat.max), options: .UsesLineFragmentOrigin, attributes: attributes, context: nil)
+        let attributes = [NSFontAttributeName : font]
+        let rect = (text ?? "" as NSString).boundingRectWithSize(CGSize(width: CGFloat.max, height: CGFloat.max), options: .UsesLineFragmentOrigin, attributes: attributes, context: nil)
         
         return rect.width
     }

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -8,7 +8,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
+        window = UIWindow(frame: UIScreen.mainScreen().bounds)
 
         let numberOfColumns = CGFloat(4)
         let layout = UICollectionViewFlowLayout()
@@ -33,8 +33,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             remoteNavigationController.navigationBar.barStyle = .Black
         }
 
-        self.window?.rootViewController = tabBarController
-        self.window!.makeKeyAndVisible()
+        window?.rootViewController = tabBarController
+        window!.makeKeyAndVisible()
 
         return true
     }

--- a/iOS/Photo.swift
+++ b/iOS/Photo.swift
@@ -15,7 +15,7 @@ struct Photo {
     }
 
     func media(completion: (image: UIImage?, error: NSError?) -> ()) {
-        completion(image: self.placeholder, error: nil)
+        completion(image: placeholder, error: nil)
     }
 
     static func constructRemoteElements() -> [String : [Photo]] {

--- a/iOS/PhotoCell.swift
+++ b/iOS/PhotoCell.swift
@@ -13,9 +13,9 @@ class PhotoCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.clipsToBounds = true
-        self.backgroundColor = UIColor.blackColor()
-        self.addSubview(self.imageView)
+        clipsToBounds = true
+        backgroundColor = UIColor.blackColor()
+        addSubview(imageView)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -23,12 +23,12 @@ class PhotoCell: UICollectionViewCell {
     }
 
     func display(photo: Photo) {
-        self.imageView.image = photo.placeholder
+        imageView.image = photo.placeholder
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        self.imageView.frame = CGRect(x: 0, y: 0, width: self.frame.width, height: self.frame.height)
+        imageView.frame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
     }
 }

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -25,34 +25,34 @@ class RemoteCollectionController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.collectionView?.backgroundColor = UIColor.whiteColor()
-        self.collectionView?.registerClass(PhotoCell.self, forCellWithReuseIdentifier: PhotoCell.Identifier)
-        self.collectionView?.registerClass(SectionHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: SectionHeader.Identifier)
-        self.collectionView?.showsVerticalScrollIndicator = false
+        collectionView?.backgroundColor = UIColor.whiteColor()
+        collectionView?.registerClass(PhotoCell.self, forCellWithReuseIdentifier: PhotoCell.Identifier)
+        collectionView?.registerClass(SectionHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: SectionHeader.Identifier)
+        collectionView?.showsVerticalScrollIndicator = false
 
         var count = 0
-        for i in 0 ..< self.sections.count {
-            if let photos = self.sections[Photo.title(index: i)] {
+        for i in 0 ..< sections.count {
+            if let photos = sections[Photo.title(index: i)] {
                 count += photos.count
             }
         }
 
         let keyWindow = UIApplication.sharedApplication().keyWindow!
-        keyWindow.addSubview(self.overlayView)
-        keyWindow.addSubview(self.sectionScrubber)
+        keyWindow.addSubview(overlayView)
+        keyWindow.addSubview(sectionScrubber)
     }
 
     override func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
-        return self.sections.count
+        return sections.count
     }
 
     override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return self.sections[Photo.title(index: section)]?.count ?? 0
+        return sections[Photo.title(index: section)]?.count ?? 0
     }
 
     override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(PhotoCell.Identifier, forIndexPath: indexPath) as! PhotoCell
-        if let photos = self.sections[Photo.title(index: indexPath.section)] {
+        if let photos = sections[Photo.title(index: indexPath.section)] {
             let photo = photos[indexPath.row]
             cell.display(photo)
         }
@@ -68,7 +68,7 @@ class RemoteCollectionController: UICollectionViewController {
     }
 
     override func scrollViewDidScroll(scrollView: UIScrollView) {
-        self.sectionScrubber.updateFrame { indexPath in
+        sectionScrubber.updateFrame { indexPath in
             if let indexPath = indexPath {
                 self.sectionScrubber.updateSectionTitle(Photo.title(index: indexPath.section))
             }
@@ -76,7 +76,7 @@ class RemoteCollectionController: UICollectionViewController {
     }
 
     override func scrollViewDidEndDragging(scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        self.sectionScrubber.updateFrame { indexPath in
+        sectionScrubber.updateFrame { indexPath in
             if let indexPath = indexPath {
                 self.sectionScrubber.updateSectionTitle(Photo.title(index: indexPath.section))
             }

--- a/iOS/SectionHeader.swift
+++ b/iOS/SectionHeader.swift
@@ -12,8 +12,8 @@ class SectionHeader: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.backgroundColor = UIColor.whiteColor()
-        self.addSubview(self.titleLabel)
+        backgroundColor = UIColor.whiteColor()
+        addSubview(titleLabel)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -23,6 +23,6 @@ class SectionHeader: UICollectionReusableView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        self.titleLabel.frame = CGRect(x: 10, y: 40, width: self.frame.width, height: self.frame.height)
+        titleLabel.frame = CGRect(x: 10, y: 40, width: frame.width, height: frame.height)
     }
 }


### PR DESCRIPTION
In this codebase sometimes we use self and sometimes we don't. To make it easier to keep consistency in what we write, I think is better if we only use `self.` when it's required by the compiler, for example in usage inside closures or when assigning values to a variable that has the same name.
