### PR TITLE
Rotation support

### DIFF
--- a/Sources/SectionScrubber.swift
+++ b/Sources/SectionScrubber.swift
@@ -35,6 +35,8 @@ public class SectionScrubber: UIView {
     private let dragGestureRecognizer = UIPanGestureRecognizer()
     private let longPressGestureRecognizer = UILongPressGestureRecognizer()
 
+    private let scrubberGestureView = UIView()
+
     private unowned var collectionView: UICollectionView
 
     public var sectionLabelImage: UIImage? {
@@ -100,7 +102,6 @@ public class SectionScrubber: UIView {
 
         super.init(frame: CGRectZero)
 
-        self.setScrubberFrame()
         self.addSubview(scrubberImageView)
 
         self.setSectionlabelFrame()
@@ -114,14 +115,30 @@ public class SectionScrubber: UIView {
         self.longPressGestureRecognizer.cancelsTouchesInView = false
         self.longPressGestureRecognizer.delegate = self
 
-        let scrubberGestureView = UIView(frame: CGRectMake(self.containingViewFrame.width - self.scrubberGestureWidth, 0, self.scrubberGestureWidth, self.viewHeight))
-        scrubberGestureView.addGestureRecognizer(self.longPressGestureRecognizer)
-        scrubberGestureView.addGestureRecognizer(self.dragGestureRecognizer)
+        self.scrubberGestureView.addGestureRecognizer(self.longPressGestureRecognizer)
+        self.scrubberGestureView.addGestureRecognizer(self.dragGestureRecognizer)
         self.addSubview(scrubberGestureView)
     }
 
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    var originalOriginY: CGFloat?
+    override public func layoutSubviews() {
+        if self.originalOriginY == nil {
+            self.originalOriginY = -self.collectionView.bounds.origin.y
+        }
+
+        if let originalOriginY = self.originalOriginY {
+            self.containingViewFrame = CGRectMake(0, originalOriginY, self.collectionView.bounds.width, self.collectionView.bounds.height - originalOriginY - self.viewHeight)
+            self.containingViewContentSize = self.collectionView.contentSize
+            self.updateFrame() { _ in }
+        }
+
+        self.setScrubberFrame()
+        self.updateFrame() { _ in }
+        self.scrubberGestureView.frame = CGRectMake(self.containingViewFrame.width - self.scrubberGestureWidth, 0, self.scrubberGestureWidth, self.viewHeight)
     }
 
     public func updateFrame(completion: ((indexPath: NSIndexPath?) -> Void)) {
@@ -244,19 +261,6 @@ public class SectionScrubber: UIView {
             return
         }
         self.sectionLabel.hide()
-    }
-
-    var originalOriginY: CGFloat?
-    override public func layoutSubviews() {
-        if self.originalOriginY == nil {
-            self.originalOriginY = -self.collectionView.bounds.origin.y
-        }
-
-        if let originalOriginY = self.originalOriginY {
-            self.containingViewFrame = CGRectMake(0, originalOriginY, self.collectionView.bounds.width, self.collectionView.bounds.height - originalOriginY - self.viewHeight)
-            self.containingViewContentSize = self.collectionView.contentSize
-            self.updateFrame() { _ in }
-        }
     }
 }
 

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -44,7 +44,11 @@ class RemoteCollectionController: UICollectionViewController {
 
     override func viewDidLayoutSubviews(){
         super.viewDidLayoutSubviews()
-        self.sectionScrubber.originalOriginY = self.navigationController?.navigationBar.bounds.height
+
+        if let originY = self.navigationController?.navigationBar.bounds.height{
+            let originYWithStatusBar = originY + (UIApplication.sharedApplication().statusBarHidden ? 0 : 20)
+            self.sectionScrubber.originalOriginY = originYWithStatusBar
+        }
     }
 
     override func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -42,6 +42,11 @@ class RemoteCollectionController: UICollectionViewController {
         keyWindow.addSubview(self.sectionScrubber)
     }
 
+    override func viewDidLayoutSubviews(){
+        super.viewDidLayoutSubviews()
+        self.sectionScrubber.originalOriginY = self.navigationController?.navigationBar.bounds.height
+    }
+
     override func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
         return self.sections.count
     }

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -4,7 +4,7 @@ class RemoteCollectionController: UICollectionViewController {
     var sections = Photo.constructRemoteElements()
 
     lazy var overlayView: UIView = {
-        let view = UIView(frame: UIScreen.mainScreen().bounds)
+        let view = UIView()
         view.backgroundColor = UIColor.blackColor()
         view.alpha = 0.0
 
@@ -44,6 +44,8 @@ class RemoteCollectionController: UICollectionViewController {
 
     override func viewDidLayoutSubviews(){
         super.viewDidLayoutSubviews()
+
+        self.overlayView.frame = UIScreen.mainScreen().bounds
 
         if let originY = self.navigationController?.navigationBar.bounds.height{
             let originYWithStatusBar = originY + (UIApplication.sharedApplication().statusBarHidden ? 0 : 20)

--- a/iOS/RemoteCollectionController.swift
+++ b/iOS/RemoteCollectionController.swift
@@ -42,13 +42,13 @@ class RemoteCollectionController: UICollectionViewController {
         keyWindow.addSubview(self.sectionScrubber)
     }
 
-    override func viewDidLayoutSubviews(){
+    override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
         self.overlayView.frame = UIScreen.mainScreen().bounds
 
-        if let originY = self.navigationController?.navigationBar.bounds.height{
-            let originYWithStatusBar = originY + (UIApplication.sharedApplication().statusBarHidden ? 0 : 20)
+        if let originY = self.navigationController?.navigationBar.bounds.height {
+            let originYWithStatusBar = originY + (UIApplication.sharedApplication().statusBarFrame.height)
             self.sectionScrubber.originalOriginY = originYWithStatusBar
         }
     }


### PR DESCRIPTION
Update the frames of the section scrubber in layoutSubviews

Update the originalOriginY int he layoutSubviews of the CollectionView

One issue in this demo project is that it doesn't take the tabBar into account, for this we need to set a custom height property on the section scrubber (just like the originalOriginY). We could make these two properties settable, or just set the containingViewFrame as one property. But we can make a new PR for this.
