### PR TITLE
Account for section headers when updating section title

### DIFF
--- a/Sources/SectionScrubber.swift
+++ b/Sources/SectionScrubber.swift
@@ -219,8 +219,15 @@ public class SectionScrubber: UIView {
      a cell, this is not going to return an index path.
      **/
     private func indexPath(at point: CGPoint) -> NSIndexPath? {
-        if let indexPath = self.collectionView?.indexPathForItemAtPoint(point) {
+        guard let collectionView = self.collectionView else { return nil }
+        if let indexPath = collectionView.indexPathForItemAtPoint(point) {
             return indexPath
+        }
+        for indexPath in collectionView.indexPathsForVisibleSupplementaryElementsOfKind(UICollectionElementKindSectionHeader) {
+            let view = collectionView.supplementaryViewForElementKind(UICollectionElementKindSectionHeader, atIndexPath: indexPath)
+            if view.frame.contains(point) {
+                return indexPath
+            }
         }
         return nil
     }


### PR DESCRIPTION
This updates the title much sooner, as soon as we hit the section header, instead of waiting until we hit the first item row. So far it seems to work fine and avoid the misnamed section issue for the scrubber.

Doing more testing and checking the code some more. Feedback is always appreciated before merging.
